### PR TITLE
Issue 1

### DIFF
--- a/flock/closures.py
+++ b/flock/closures.py
@@ -62,9 +62,9 @@ def reference(flock, *indexes, **kwargs):
             for index in indexes:
                 currObj = currObj[index]
             return currObj
-        except (KeyError, FlockException) as e:
-            if isinstance(e, FlockException) and not isinstance(e.__cause__, KeyError):
-                raise
+        except FlockException:
+            raise
+        except KeyError as e:
             if 'default' in kwargs:
                 return kwargs['default']
             else:

--- a/flock/core.py
+++ b/flock/core.py
@@ -405,7 +405,7 @@ class MetaAggregator():
         return ret
 
 
-class FlockException(Exception): pass
+class FlockException(KeyError): pass
 
 
 class FlockAggregator(FlockBase, Mapping):

--- a/flock/core.py
+++ b/flock/core.py
@@ -91,8 +91,9 @@ class MutableFlock(FlockBase):
         if key in self.cache:
             return self.cache[key]
         else:
+            promise = self.promises[key]
             try:
-                ret = self.promises[key]()
+                ret = promise()
             except Exception as e:
                 raise FlockException('Error calculating key:%s' % key) from e
             self.cache[key] = ret
@@ -294,7 +295,8 @@ class FlockDict(MutableFlock, MutableMapping):
                         ret[key] = e
                     else:
                         raise
-            self.cache[key] = ret[key]
+            if not isinstance(ret, MutableMapping):
+                self.cache[key] = ret[key]
         return ret
 
     def dataset(self):

--- a/flock/util.py
+++ b/flock/util.py
@@ -7,15 +7,16 @@ log = logging.getLogger(__name__)
 
 __author__ = 'Andy Fundinger'
 
-class FlockException(Exception): pass
+
+class FlockException(KeyError): pass
 
 def patch(map, key_list, val):
     for key in key_list[0:-1]:
         try:
             map = map[key]
-        except (KeyError, FlockException) as e:
-            if isinstance(e, FlockException) and not isinstance(e.__cause__, KeyError):
-                raise
+        except FlockException as e:
+            raise
+        except KeyError as e:
             map[key] = {}
             map = map[key]
     if key_list[-1] == 'append':

--- a/test/test_flockdict.py
+++ b/test/test_flockdict.py
@@ -344,20 +344,28 @@ class ShearTestCase(unittest.TestCase):
         self.flock = FlockDict()
         self.flock['a'] = 'Original Value'
         self.flock['b'] = {'i': 'Original Value', 'ii': 42}
+        self.flock['c'] = [1, 2, 3]
+        self.flock['d'] = set('ABC')
 
     def test_consistent_types(self):
-        pre_shear_type = type(self.flock['b'])
-        self.flock.shear()
-        post_shear_type = type(self.flock['b'])
-        assert pre_shear_type is post_shear_type
+        for collection in 'bcd':
+            pre_shear_type = type(self.flock[collection])
+            self.flock.shear()
+            post_shear_type = type(self.flock[collection])
+            assert pre_shear_type is post_shear_type
 
     def test_edit_post_shear(self):
         self.flock.shear()
         self.flock['b']['i'] = 'New Value'
+        self.flock['c'].append(4)
+        self.flock['d'].add('D')
+        assert self.flock['c'] == [1, 2, 3, 4]
         assert self.flock['b']['i'] == 'New Value'
+        assert 'D' in self.flock['d']
         self.flock['unreleated'] = 'Something'
         assert self.flock['b']['i'] == 'New Value'
-
+        assert self.flock['c'] == [1, 2, 3, 4]
+        assert 'D' in self.flock['d']
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_flockdict.py
+++ b/test/test_flockdict.py
@@ -1,5 +1,6 @@
-from pytest import raises
 from types import FunctionType
+
+from pytest import raises
 
 from flock.closures import toggle, reference
 from flock.core import FlockDict, Aggregator, MetaAggregator, FlockAggregator, FlockList
@@ -335,6 +336,27 @@ class FlockAggregatorTestCase(unittest.TestCase):
 
     def assertContentsEqual(self, param, param1, *args, **kwargs):
         return self.assertSetEqual(set(param), set(param1), *args, **kwargs)
+
+
+class ShearTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.flock = FlockDict()
+        self.flock['a'] = 'Original Value'
+        self.flock['b'] = {'i': 'Original Value', 'ii': 42}
+
+    def test_consistent_types(self):
+        pre_shear_type = type(self.flock['b'])
+        self.flock.shear()
+        post_shear_type = type(self.flock['b'])
+        assert pre_shear_type is post_shear_type
+
+    def test_edit_post_shear(self):
+        self.flock.shear()
+        self.flock['b']['i'] = 'New Value'
+        assert self.flock['b']['i'] == 'New Value'
+        self.flock['unreleated'] = 'Something'
+        assert self.flock['b']['i'] == 'New Value'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Mutable mappings are no longer longer cached

* Test cases based on report https://github.com/Ciemaar/flock/issues/1
* fixes for the same

Made FlockException a subtype of KeyError to allow it to be handled more naively
Separate handling at key points