### PR TITLE
Add UP checks to ruff and upgrade code

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ line-length = 160
 src = ["src", "test"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I"]
+select = ["E", "F", "W", "I", "UP"]
 ignore = ["E731"]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -1,8 +1,8 @@
 import inspect
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable, Mapping
 from itertools import chain
 from pprint import pformat
-from typing import Iterable, Mapping
 
 from closure_collector.util import ClosureCollectorException, is_rule, rebind
 
@@ -66,7 +66,7 @@ class DynamicClosureCollector(CCBase):
 
     def __init__(self, root=None):
         """ """
-        super(DynamicClosureCollector, self).__init__()
+        super().__init__()
         self.cache = {}
         self.root = root
         self.peers = set()
@@ -98,7 +98,7 @@ class ClosurePromiseCollector(DynamicClosureCollector):
     def __init__(self, root=None):
         """ """
         self.promises = {}
-        super(ClosurePromiseCollector, self).__init__(root=root)
+        super().__init__(root=root)
 
     def __setattr__(self, item, val):
         """
@@ -110,7 +110,7 @@ class ClosurePromiseCollector(DynamicClosureCollector):
         Any other handling should be dealt with via direct access to the promises dict.
         """
         if item in CLOSURE_ATTRS:
-            return super(ClosurePromiseCollector, self).__setattr__(item, val)
+            return super().__setattr__(item, val)
         value = self.make_callable(val)
         self.promises[item] = value
         self.clear_cache()
@@ -123,19 +123,19 @@ class ClosurePromiseCollector(DynamicClosureCollector):
         :return: the value of the lamba when executed
         """
         if item.startswith("_") or item in {"root", "cache", "peers", "promises"}:
-            return super(ClosurePromiseCollector, self).__getattribute__(item)
+            return super().__getattribute__(item)
         if item in self.cache:
             return self.cache[item]
         else:
             if item in self.promises:
                 promise = self.promises[item]
             else:  # If the promise is not there, fallback ultimately to an error.
-                return super(ClosurePromiseCollector, self).__getattribute__(item)
+                return super().__getattribute__(item)
 
             try:
                 ret = promise()
             except Exception as e:
-                raise ClosureCollectorException("Error calculating attribute:%s" % item) from e
+                raise ClosureCollectorException(f"Error calculating attribute:{item}") from e
             self.cache[item] = ret
             return ret
 
@@ -177,7 +177,7 @@ class ClosureCollector(ClosurePromiseCollector):
         Values from indict are assigned to self one at a time.
 
         """
-        super(ClosureCollector, self).__init__()
+        super().__init__()
         for key, value in indict.items():
             setattr(self, key, value)
 
@@ -288,18 +288,17 @@ class ClosureReduction:
         try:
             cross_items = [getattr(source, item) for source in self.get_sources() if hasattr(source, item)]
             if not cross_items:
-                raise AttributeError("Attribute %s not found" % item)
+                raise AttributeError(f"Attribute {item} not found")
             return self.function(cross_items)
         except AttributeError:
             raise
         except Exception as e:
             raise ClosureCollectorException(
-                "Error Calculating %s:  " % item
+                f"Error Calculating {item}:  "
                 + str(e)
                 + "\n"
                 + ",".join(
-                    "%s:%s"
-                    % (
+                    "{}:{}".format(
                         source,
                         getattr(source, item, "NO VALUE"),
                     )

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -7,10 +7,10 @@ from collections.abc import (
     Mapping,
     MutableMapping,
     MutableSequence,
+    Sequence,
 )
 from copy import copy
 from itertools import chain
-from typing import Sequence
 
 from closure_collector.core import CCBase, DynamicClosureCollector
 from closure_collector.util import is_rule
@@ -70,7 +70,7 @@ class MutableFlock(FlockBase, DynamicClosureCollector):
 
     def __init__(self, root=None):
         """Initialize the object."""
-        super(MutableFlock, self).__init__()
+        super().__init__()
 
     @abstractmethod
     def __setitem__(self, key, val):
@@ -114,7 +114,7 @@ class PromiseFlock(MutableFlock):
 
     def __init__(self, root=None):
         """Initialize the object."""
-        super(PromiseFlock, self).__init__(root=root)
+        super().__init__(root=root)
         self.promises = {}
 
     def __setitem__(self, key, val):
@@ -144,7 +144,7 @@ class PromiseFlock(MutableFlock):
             try:
                 ret = promise()
             except Exception as e:
-                raise FlockException("Error calculating key:%s" % key) from e
+                raise FlockException(f"Error calculating key:{key}") from e
             self.cache[key] = ret
             return ret
 
@@ -187,7 +187,7 @@ class FlockList(PromiseFlock, MutableSequence):
         Values from indict are assigned to self one at a time.
 
         """
-        super(FlockList, self).__init__()
+        super().__init__()
         self.promises = []
         self.cache = {}
         self.root = root
@@ -281,7 +281,7 @@ class FlockDict(PromiseFlock, MutableMapping):
         Values from indict are assigned to self one at a time.
 
         """
-        super(FlockDict, self).__init__()
+        super().__init__()
         self.promises = {}
         self.cache = {}
         self.root = root
@@ -421,12 +421,8 @@ class Aggregator:
                     try:
                         self.function([value])
                     except Exception as e:
-                        msg = "function {function} incompatible with value {value} exception: {e}".format(
-                            e=str(e),
-                            value=value,
-                            function=self.function.__name__,
-                        )
-                        ret[key]["Source: {sourceNo}".format(sourceNo=sourceNo)] = msg
+                        msg = f"function {self.function.__name__} incompatible with value {value} exception: {str(e)}"
+                        ret[key][f"Source: {sourceNo}"] = msg
                         # raise
         return ret
 
@@ -516,13 +512,13 @@ class FlockAggregator(FlockBase, Mapping):
         try:
             cross_items = [source[key] for source in self.get_sources() if key in source]
             if not cross_items:
-                raise KeyError("Key %s not found" % key)
+                raise KeyError(f"Key {key} not found")
             return self.function(cross_items)
         except KeyError:
             raise
         except Exception as e:
             raise FlockException(
-                "Error Calculating %s:  " % key + str(e) + "\n" + ",".join("%s:%s" % (source, source[key]) for source in self.get_sources() if key in source)
+                f"Error Calculating {key}:  " + str(e) + "\n" + ",".join(f"{source}:{source[key]}" for source in self.get_sources() if key in source)
             ) from e
 
     def __len__(self):
@@ -560,12 +556,8 @@ class FlockAggregator(FlockBase, Mapping):
                     try:
                         self.function([value])
                     except Exception as e:
-                        msg = "function {function} incompatible with value {value} exception: {e}".format(
-                            e=str(e),
-                            value=value,
-                            function=self.function.__name__,
-                        )
-                        ret[key]["Source: {sourceNo}".format(sourceNo=sourceNo)] = msg
+                        msg = f"function {self.function.__name__} incompatible with value {value} exception: {str(e)}"
+                        ret[key][f"Source: {sourceNo}"] = msg
                         # raise
         return ret
 
@@ -588,4 +580,4 @@ class FlockAggregator(FlockBase, Mapping):
         return ret
 
     def __repr__(self):
-        return "flock.core.FlockAggregator(%s)" % str(self.shear())
+        return f"flock.core.FlockAggregator({str(self.shear())})"

--- a/src/flock/util.py
+++ b/src/flock/util.py
@@ -1,6 +1,5 @@
 import logging
-from collections.abc import MutableMapping
-from typing import Hashable
+from collections.abc import Hashable, MutableMapping
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Added `UP` (pyupgrade) rules to `ruff`'s `select` list in `pyproject.toml` and applied automated fixes using `ruff check --fix` and `ruff check --fix --unsafe-fixes`. This updates string formatting to f-strings, simplifies `super()` calls, and updates typing imports to modern equivalents. All tests and lint checks pass.

---
*PR created automatically by Jules for task [151333115209127316](https://jules.google.com/task/151333115209127316) started by @Ciemaar*