### PR TITLE
🧹 Refactor: Replace mutable default lists in `check` methods with `None`

### DIFF
--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -196,15 +196,17 @@ class ClosureCollector(ClosurePromiseCollector):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this ClosureCollector from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this ClosureCollector from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -317,14 +319,16 @@ class ClosureReduction:
     def shear(self):
         return NotImplemented
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         return {}
         # ret = defaultdict(dict)
         # for key in set(chain.from_iterable(source.keys() for source in self.sources)):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -213,15 +213,17 @@ class FlockList(PromiseFlock, MutableSequence):
         rels.update(peer for peer in self.peers if hasattr(peer, "clear_cache"))
         return rels
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockList from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockList from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in enumerate(self.promises):
             if hasattr(value, "check"):
@@ -308,15 +310,17 @@ class FlockDict(PromiseFlock, MutableMapping):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockDict from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -404,14 +408,16 @@ class Aggregator:
         """
         return self.shear()
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
@@ -539,14 +545,16 @@ class FlockAggregator(FlockBase, Mapping):
         else:
             return self.sources
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: list the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -418,7 +418,7 @@ class Aggregator:
         """
         if path is None:
             path = []
-        ret = defaultdict(dict)
+        ret: defaultdict = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
                 if key in source:
@@ -555,7 +555,7 @@ class FlockAggregator(FlockBase, Mapping):
         """
         if path is None:
             path = []
-        ret = defaultdict(dict)
+        ret: defaultdict = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):
                 if key in source:


### PR DESCRIPTION
🎯 **What:** Replaced the mutable default argument `path=[]` with `path: list | None = None` across all instances of `check` methods in the core library and the backwards compatibility layer (`closure_collector/core.py` and `flock/core.py`).
💡 **Why:** Mutable default arguments in Python are evaluated once when the function is defined, not each time the function is called. This can lead to bugs where state persists and accumulates across calls. While this wasn't actively breaking anything based on test results, removing it improves code safety, robustness, and maintainability.
✅ **Verification:** Re-ran `tox -e py312` testing suites and verified that all test continue to pass flawlessly. Re-ran code linting (`tox -e lint`), ensuring the typing changes were successfully integrated.
✨ **Result:** Improved code health across all checking methods by explicitly typing and defaulting optional inputs to `None`, instantiating new lists only when strictly necessary inside the method body.

---
*PR created automatically by Jules for task [6894132876078765781](https://jules.google.com/task/6894132876078765781) started by @Ciemaar*