### PR TITLE
🧹 [code health] Refactor mutable default argument in check methods

### DIFF
--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -23,10 +23,10 @@ class CCBase(metaclass=ABCMeta):
     """Base class for Closure Collector Objects of all sorts"""
 
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
         """
 
@@ -196,15 +196,17 @@ class ClosureCollector(ClosurePromiseCollector):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this ClosureCollector from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this ClosureCollector from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -317,14 +319,16 @@ class ClosureReduction:
     def shear(self):
         return NotImplemented
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         return {}
         # ret = defaultdict(dict)
         # for key in set(chain.from_iterable(source.keys() for source in self.sources)):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -30,10 +30,10 @@ __author__ = "Andy Fundinger"
 
 class FlockBase(CCBase, Mapping, metaclass=ABCMeta):
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
         """
 
@@ -213,15 +213,17 @@ class FlockList(PromiseFlock, MutableSequence):
         rels.update(peer for peer in self.peers if hasattr(peer, "clear_cache"))
         return rels
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockList from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockList from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in enumerate(self.promises):
             if hasattr(value, "check"):
@@ -308,15 +310,17 @@ class FlockDict(PromiseFlock, MutableMapping):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockDict from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -404,15 +408,17 @@ class Aggregator:
         """
         return self.shear()
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
-        ret = defaultdict(dict)
+        if path is None:
+            path = []
+        ret: defaultdict = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
                 if key in source:
@@ -539,15 +545,17 @@ class FlockAggregator(FlockBase, Mapping):
         else:
             return self.sources
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+        :type path: list | None the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
-        ret = defaultdict(dict)
+        if path is None:
+            path = []
+        ret: defaultdict = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):
                 if key in source:


### PR DESCRIPTION
🎯 **What:** Replaced the mutable default argument `path=[]` with `path=None` in the `check` methods of several classes across `src/closure_collector/core.py` and `src/flock/core.py`. Updated typing to `path: list | None = None` and modified corresponding docstrings.
💡 **Why:** Having mutable objects as default arguments in Python creates an issue where the object is evaluated once at function definition, leading to the same list instance being shared across multiple calls, causing unexpected state mutations. The refactor solves this issue, thereby improving the correctness and maintainability of the code.
✅ **Verification:** Verified by confirming the new type check in `tox -e type`, format pass in `tox -e lint`, and execution in `tox -e py312`.
✨ **Result:** Improved robustness by ensuring that calls to the `check` method without a `path` parameter default cleanly to a fresh list, without any behavioral regression.

---
*PR created automatically by Jules for task [2579815750908594879](https://jules.google.com/task/2579815750908594879) started by @Ciemaar*