### PR TITLE
🧹 Fix mutable default arguments across codebase

### DIFF
--- a/examples/mythica/model.py
+++ b/examples/mythica/model.py
@@ -220,7 +220,9 @@ class Skill:
 
 
 class HeroicSkill(Skill):
-    def __init__(self, name, skill_type=HEROIC, cost=1, level=1, bonuses={}):
+    def __init__(self, name, skill_type=HEROIC, cost=1, level=1, bonuses: dict | None = None):
+        if bonuses is None:
+            bonuses = {}
         assert skill_type == HEROIC
         super().__init__(name, skill_type, cost, xp=None, level=level)
         self.bonuses = bonuses

--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -23,10 +23,11 @@ class CCBase(metaclass=ABCMeta):
     """Base class for Closure Collector Objects of all sorts"""
 
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
         """
 
@@ -196,15 +197,17 @@ class ClosureCollector(ClosurePromiseCollector):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this ClosureCollector from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this ClosureCollector from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -317,14 +320,17 @@ class ClosureReduction:
     def shear(self):
         return NotImplemented
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         return {}
         # ret = defaultdict(dict)
         # for key in set(chain.from_iterable(source.keys() for source in self.sources)):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -30,10 +30,11 @@ __author__ = "Andy Fundinger"
 
 class FlockBase(CCBase, Mapping, metaclass=ABCMeta):
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
         """
 
@@ -213,15 +214,17 @@ class FlockList(PromiseFlock, MutableSequence):
         rels.update(peer for peer in self.peers if hasattr(peer, "clear_cache"))
         return rels
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockList from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockList from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in enumerate(self.promises):
             if hasattr(value, "check"):
@@ -308,15 +311,17 @@ class FlockDict(PromiseFlock, MutableMapping):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this FlockDict from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -404,15 +409,18 @@ class Aggregator:
         """
         return self.shear()
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
-        ret = defaultdict(dict)
+        if path is None:
+            path = []
+        ret: dict = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
                 if key in source:
@@ -539,15 +547,18 @@ class FlockAggregator(FlockBase, Mapping):
         else:
             return self.sources
 
-    def check(self, path=[]):
+    def check(self, path: list | None = None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
+
+        :param path: the path to this object, will be prepended to any errors generated
         :return: list of errors that prevent items in this Aggregator from being sheared.
 
         NOT YET PROPERLY IMPLEMENTED
         """
-        ret = defaultdict(dict)
+        if path is None:
+            path = []
+        ret: dict = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):
                 if key in source:


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Replaced mutable default arguments (e.g., `path=[]` and `bonuses={}`) across the codebase with `None` and properly initialized them inside the method bodies. Also updated method signatures with correct type hints (`list | None`, `dict | None`) and reformatted the docstrings to remove outdated `:type:` strings.

💡 **Why:** How this improves maintainability
Mutable default arguments in Python are evaluated once at function definition time, meaning the same mutable object instance is shared across all calls that use the default. This is a common footgun and a well-known Python anti-pattern that can cause hard-to-debug state leakage.

✅ **Verification:** How you confirmed the change is safe
Ran `tox -e lint`, `tox -e type`, and `tox -e py312` tests. All tests passed correctly, and static types with mypy showed no regressions.

✨ **Result:** The improvement achieved
A cleaner, safer codebase immune to mutable default argument side-effects, with modern and correct typing conventions applied throughout.

---
*PR created automatically by Jules for task [5896791641101663496](https://jules.google.com/task/5896791641101663496) started by @Ciemaar*