### PR TITLE
🧹 Code Health: Remove commented-out dead code in flock core

### DIFF
--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -304,10 +304,6 @@ class FlockDict(PromiseFlock, MutableMapping):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.shear()},{self.root})"
 
-    #
-    # def __hash__(self):
-    #     return id(self)
-
     def check(self, path=[]):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
@@ -394,9 +390,6 @@ class Aggregator:
         """
         return self.function(source[key] for source in self.sources if key in source)
 
-    # def __getattr__(self, key):
-    #     return self[key]()
-
     def __call__(self):
         """
         When an Aggregator is returned from a FlockDict or otherwise called, shear it.
@@ -460,9 +453,6 @@ class MetaAggregator:
 
     def __getitem__(self, key):
         return lambda: self.function(source[key] for source in self.source_function() if key in source)
-
-    # def __getattr__(self, key):
-    #     return self[key]()
 
     def __call__(self):
         return self.shear()


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code (`__hash__` in `FlockDict` and `__getattr__` in `Aggregator` and `MetaAggregator`).
💡 **Why:** This improves maintainability and readability of the codebase by getting rid of old, non-functional code fragments.
✅ **Verification:** Verified via tests, linters, and type checkers (`tox -e py312`, `tox -e lint`, and `tox -e type`). All checks pass. No behavior changes introduced.
✨ **Result:** Cleaned up three sections of dead code in `src/flock/core.py` safely.

---
*PR created automatically by Jules for task [6858273724303038721](https://jules.google.com/task/6858273724303038721) started by @Ciemaar*