### PR TITLE
🧹 Code Health Improvement: Clean up dead code in flock.core

### DIFF
--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -304,10 +304,6 @@ class FlockDict(PromiseFlock, MutableMapping):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.shear()},{self.root})"
 
-    #
-    # def __hash__(self):
-    #     return id(self)
-
     def check(self, path=[]):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
@@ -385,7 +381,7 @@ class Aggregator:
         self.sources = sources
         self.function = fn
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str):
         """
         Perform the aggregation for the given key across all the sources.
 
@@ -394,13 +390,10 @@ class Aggregator:
         """
         return self.function(source[key] for source in self.sources if key in source)
 
-    # def __getattr__(self, key):
-    #     return self[key]()
-
-    def __call__(self):
+    def __call__(self) -> dict:
         """
         When an Aggregator is returned from a FlockDict or otherwise called, shear it.
-        :return:  a sheared version of this Aggrgator
+        :return:  a sheared version of this Aggregator
         """
         return self.shear()
 
@@ -458,13 +451,10 @@ class MetaAggregator:
         self.source_function = source_function
         self.function = fn
 
-    def __getitem__(self, key):
+    def __getitem__(self, key: str):
         return lambda: self.function(source[key] for source in self.source_function() if key in source)
 
-    # def __getattr__(self, key):
-    #     return self[key]()
-
-    def __call__(self):
+    def __call__(self) -> dict:
         return self.shear()
 
     def shear(self, record_errors=False):


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code block (`__getattr__` and `__hash__` methods) from `Aggregator`, `MetaAggregator`, and `FlockDict` in `src/flock/core.py`. Updated type hints and fixed a typo in a nearby docstring as well.
💡 **Why:** Dead, commented-out code clutters the codebase, confuses developers reading it, and provides no functional value. Removing this code improves maintainability and readability. 
✅ **Verification:** Ran `tox -e py312`, `tox -e lint`, and `tox -e type` to verify that there are no regressions in test coverage, no static analysis issues, and that format/linting remains correct.
✨ **Result:** A cleaner file without misleading commented-out snippets.

---
*PR created automatically by Jules for task [8403954575179234715](https://jules.google.com/task/8403954575179234715) started by @Ciemaar*