### PR TITLE
🧹 chore: Clean up commented code and update type hints/docstrings

### DIFF
--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -23,11 +23,15 @@ class CCBase(metaclass=ABCMeta):
     """Base class for Closure Collector Objects of all sorts"""
 
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list[str]) -> dict:
         """
-        check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this Aggregator from being sheared.
+        Check for any contents that would prevent this Aggregator from being used normally, especially sheared.
+
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
 
     @abstractmethod
@@ -192,18 +196,17 @@ class ClosureCollector(ClosurePromiseCollector):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.shear()})"
 
-    #
-    # def __hash__(self):
-    #     return id(self)
-
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this ClosureCollector from being used normally, esp sheared.
+        Check for any contents that would prevent this ClosureCollector from being used normally, especially sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this ClosureCollector from being sheared.
+        NOT YET PROPERLY IMPLEMENTED.
 
-        NOT YET PROPERLY IMPLEMENTED
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this ClosureCollector from being sheared.
         """
         ret = {}
         for key, value in self.promises.items():
@@ -317,13 +320,17 @@ class ClosureReduction:
     def shear(self):
         return NotImplemented
 
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this Aggregator from being sheared.
+        Check for any contents that would prevent this Aggregator from being used normally, especially sheared.
 
-        NOT YET PROPERLY IMPLEMENTED
+        NOT YET PROPERLY IMPLEMENTED.
+
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
         return {}
         # ret = defaultdict(dict)

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -30,11 +30,15 @@ __author__ = "Andy Fundinger"
 
 class FlockBase(CCBase, Mapping, metaclass=ABCMeta):
     @abstractmethod
-    def check(self, path):
+    def check(self, path: list[str]) -> dict:
         """
-        check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this Aggregator from being sheared.
+        Check for any contents that would prevent this Aggregator from being used normally, especially sheared.
+
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
 
     @abstractmethod
@@ -213,14 +217,17 @@ class FlockList(PromiseFlock, MutableSequence):
         rels.update(peer for peer in self.peers if hasattr(peer, "clear_cache"))
         return rels
 
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this FlockList from being used normally, esp sheared.
+        Check for any contents that would prevent this FlockList from being used normally, especially sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this FlockList from being sheared.
+        NOT YET PROPERLY IMPLEMENTED.
 
-        NOT YET PROPERLY IMPLEMENTED
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this FlockList from being sheared.
         """
         ret = {}
         for key, value in enumerate(self.promises):
@@ -304,18 +311,17 @@ class FlockDict(PromiseFlock, MutableMapping):
     def __repr__(self):
         return f"{self.__class__.__name__}({self.shear()},{self.root})"
 
-    #
-    # def __hash__(self):
-    #     return id(self)
-
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this FlockDict from being used normally, esp sheared.
+        Check for any contents that would prevent this FlockDict from being used normally, especially sheared.
 
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this FlockDict from being sheared.
+        NOT YET PROPERLY IMPLEMENTED.
 
-        NOT YET PROPERLY IMPLEMENTED
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this FlockDict from being sheared.
         """
         ret = {}
         for key, value in self.promises.items():
@@ -394,9 +400,6 @@ class Aggregator:
         """
         return self.function(source[key] for source in self.sources if key in source)
 
-    # def __getattr__(self, key):
-    #     return self[key]()
-
     def __call__(self):
         """
         When an Aggregator is returned from a FlockDict or otherwise called, shear it.
@@ -404,13 +407,17 @@ class Aggregator:
         """
         return self.shear()
 
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this Aggregator from being sheared.
+        Check for any contents that would prevent this Aggregator from being used normally, especially sheared.
 
-        NOT YET PROPERLY IMPLEMENTED
+        NOT YET PROPERLY IMPLEMENTED.
+
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
         ret = defaultdict(dict)
         for key in set().union(*self.sources):
@@ -460,9 +467,6 @@ class MetaAggregator:
 
     def __getitem__(self, key):
         return lambda: self.function(source[key] for source in self.source_function() if key in source)
-
-    # def __getattr__(self, key):
-    #     return self[key]()
 
     def __call__(self):
         return self.shear()
@@ -539,13 +543,17 @@ class FlockAggregator(FlockBase, Mapping):
         else:
             return self.sources
 
-    def check(self, path=[]):
+    def check(self, path: list[str] = []) -> dict:
         """
-        check for any contents that would prevent this Aggregator from being used normally, esp sheared.
-        :type path: list the path to this object, will be prepended to any errors generated
-        :return: list of errors that prevent items in this Aggregator from being sheared.
+        Check for any contents that would prevent this Aggregator from being used normally, especially sheared.
 
-        NOT YET PROPERLY IMPLEMENTED
+        NOT YET PROPERLY IMPLEMENTED.
+
+        Args:
+            path: The path to this object, will be prepended to any errors generated.
+
+        Returns:
+            A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
         ret = defaultdict(dict)
         for key in self.__iter__():

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -419,7 +419,7 @@ class Aggregator:
         Returns:
             A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
-        ret = defaultdict(dict)
+        ret: dict = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
                 if key in source:
@@ -555,7 +555,7 @@ class FlockAggregator(FlockBase, Mapping):
         Returns:
             A dictionary of errors that prevent items in this Aggregator from being sheared.
         """
-        ret = defaultdict(dict)
+        ret: dict = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):
                 if key in source:


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code block methods (`__hash__`, `__getattr__`) across `closure_collector/core.py` and `flock/core.py` and modernized the return types and docstrings for the `check()` methods while intentionally leaving the mutable default arguments untouched per instructions.

💡 **Why:** This improves the readability and code health of the source by eliminating extraneous artifacts left over from previous refactors, and making sure the method signatures accurately describe parameter types and return outcomes.

✅ **Verification:** Verified by passing all `pytest` runs via `tox -e py312` and ensuring static checks (`tox -e lint`) reported no new issues.

✨ **Result:** The codebase is cleaner, better typed, and easier to read.

---
*PR created automatically by Jules for task [14525650791033073261](https://jules.google.com/task/14525650791033073261) started by @Ciemaar*