### PR TITLE
🧹 Fix mutable default argument `path=[]` in `check` methods

### DIFF
--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -196,7 +196,7 @@ class ClosureCollector(ClosurePromiseCollector):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this ClosureCollector from being used normally, esp sheared.
 
@@ -205,6 +205,8 @@ class ClosureCollector(ClosurePromiseCollector):
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -317,7 +319,7 @@ class ClosureReduction:
     def shear(self):
         return NotImplemented
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
         :type path: list the path to this object, will be prepended to any errors generated
@@ -325,6 +327,8 @@ class ClosureReduction:
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         return {}
         # ret = defaultdict(dict)
         # for key in set(chain.from_iterable(source.keys() for source in self.sources)):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -213,7 +213,7 @@ class FlockList(PromiseFlock, MutableSequence):
         rels.update(peer for peer in self.peers if hasattr(peer, "clear_cache"))
         return rels
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this FlockList from being used normally, esp sheared.
 
@@ -222,6 +222,8 @@ class FlockList(PromiseFlock, MutableSequence):
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in enumerate(self.promises):
             if hasattr(value, "check"):
@@ -308,7 +310,7 @@ class FlockDict(PromiseFlock, MutableMapping):
     # def __hash__(self):
     #     return id(self)
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this FlockDict from being used normally, esp sheared.
 
@@ -317,6 +319,8 @@ class FlockDict(PromiseFlock, MutableMapping):
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = {}
         for key, value in self.promises.items():
             if hasattr(value, "check"):
@@ -404,7 +408,7 @@ class Aggregator:
         """
         return self.shear()
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
         :type path: list the path to this object, will be prepended to any errors generated
@@ -412,6 +416,8 @@ class Aggregator:
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = defaultdict(dict)
         for key in set().union(*self.sources):
             for sourceNo, source in enumerate(self.sources):
@@ -539,7 +545,7 @@ class FlockAggregator(FlockBase, Mapping):
         else:
             return self.sources
 
-    def check(self, path=[]):
+    def check(self, path=None):
         """
         check for any contents that would prevent this Aggregator from being used normally, esp sheared.
         :type path: list the path to this object, will be prepended to any errors generated
@@ -547,6 +553,8 @@ class FlockAggregator(FlockBase, Mapping):
 
         NOT YET PROPERLY IMPLEMENTED
         """
+        if path is None:
+            path = []
         ret = defaultdict(dict)
         for key in self.__iter__():
             for sourceNo, source in enumerate(self.get_sources()):


### PR DESCRIPTION
🎯 **What:** Replaced the mutable default argument `path=[]` with `path=None` across all 6 `check` methods in the codebase (in `FlockList`, `FlockDict`, `Aggregator`, `FlockAggregator`, `ClosureCollector` and `Aggregator` in `closure_collector`). Added `if path is None: path = []` initialization inside each method body.
💡 **Why:** Mutable default arguments in Python retain their state across function calls, which can cause subtle bugs when the default object is mutated. Initializing inside the function eliminates this common anti-pattern, improving code maintainability.
✅ **Verification:** Verified changes by running the full test suite (`tox -e py312`), code formatter/linter (`tox -e lint`), and static type checking (`tox -e type`). Code review confirmed the fix is robust and functionality-preserving.
✨ **Result:** Eliminates the code smell, providing a safer, more predictable API for `check` method usages across all classes.

---
*PR created automatically by Jules for task [8089097710739786819](https://jules.google.com/task/8089097710739786819) started by @Ciemaar*