### PR TITLE
Rebase PRs 39 and 44 (compat, tests) onto master

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,13 +67,28 @@ where = ["src"]
 namespaces = false
 
 [tool.tox]
-env_list = ["py312", "py313", "py314", "py315", "lint", "type"]
+env_list = ["py312", "py313", "py314", "py315", "pyodide", "micropython", "lint", "type"]
 
 [tool.tox.env_run_base]
 extras = ["test"]
 depends = ["clean"]
 commands = [
     ["pytest", "--cov=src", "--cov-append", "--cov-report=term-missing", "--cov-branch"]
+]
+
+
+[tool.tox.env.pyodide]
+extras = ["test"]
+deps = ["pytest-pyodide"]
+commands = [
+    ["pytest", "test/", "--run-in-pyodide"]
+]
+
+[tool.tox.env.micropython]
+skip_install = true
+allowlist_externals = ["micropython", "python3"]
+commands = [
+    ["micropython", "run_micropython_tests.py"]
 ]
 
 [tool.tox.env.report]

--- a/run_micropython_tests.py
+++ b/run_micropython_tests.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+# Ensure src is in the path
+sys.path.append(os.getcwd() + '/src')
+sys.path.append(os.getcwd() + '/test')
+
+import test_micropython_core
+test_micropython_core.run_all_tests()

--- a/src/closure_collector/compat.py
+++ b/src/closure_collector/compat.py
@@ -1,0 +1,179 @@
+__all__ = [
+    "Any",
+    "Callable",
+    "TypeVar",
+    "_FuncT",
+    "ABCMeta",
+    "abstractmethod",
+    "Iterable",
+    "Mapping",
+    "chain",
+    "pformat",
+    "Number",
+    "FunctionType",
+    "inspect",
+    "warnings",
+    "OrderedDict",
+    "defaultdict",
+    "MutableMapping",
+    "MutableSequence",
+    "Sequence",
+    "_T",
+    "copy",
+    "logging",
+    "Hashable",
+]
+
+try:
+    from typing import Any
+except ImportError:  # MicroPython compatibility fallback for missing typing
+    Any = object  # type: ignore[assignment,misc]
+
+try:
+    from collections.abc import Callable
+except ImportError:  # MicroPython compatibility fallback for missing collections.abc
+    Callable = object  # type: ignore[assignment,misc]
+
+try:
+    from typing import TypeVar
+except ImportError:  # MicroPython compatibility fallback for missing typing
+
+    def TypeVar(name: str, bound: Any = Any) -> Any:  # type: ignore[misc,no-redef]
+        return object
+
+
+try:
+    _FuncT = TypeVar("_FuncT", bound=Callable[..., Any])
+except TypeError:
+    _FuncT = object  # type: ignore[assignment,misc]
+
+try:
+    from abc import ABCMeta, abstractmethod
+except ImportError:  # MicroPython compatibility fallback for missing abc
+
+    class ABCMeta(type):  # type: ignore[no-redef]
+        pass
+
+    def abstractmethod(funcobj: _FuncT) -> _FuncT:  # noqa: UP047
+        return funcobj  # type: ignore[misc]
+
+
+try:
+    from collections.abc import Iterable, Mapping
+except ImportError:  # MicroPython compatibility fallback for missing collections.abc
+    Iterable = object  # type: ignore[assignment,misc]
+    Mapping = object  # type: ignore[assignment,misc]
+
+try:
+    from itertools import chain
+except ImportError:  # MicroPython compatibility fallback for missing itertools
+
+    class chain:  # type: ignore[no-redef]
+        def __init__(self, *iterables: Any):
+            self.iterables = iterables
+
+        def __iter__(self) -> Any:
+            for it in self.iterables:
+                yield from it
+
+        @classmethod
+        def from_iterable(cls, iterables: Any) -> Any:
+            return cls(*iterables)
+
+
+try:
+    from pprint import pformat
+except ImportError:  # MicroPython compatibility fallback for missing pprint
+    pformat = repr  # type: ignore[assignment]
+
+try:
+    from numbers import Number
+except ImportError:  # MicroPython compatibility fallback for missing numbers
+    Number = (int, float, complex)  # type: ignore[assignment,misc]
+
+try:
+    from types import FunctionType
+except ImportError:  # MicroPython compatibility fallback for missing types
+    FunctionType = type(lambda: None)  # type: ignore[assignment,misc]
+
+try:
+    import inspect
+except ImportError:  # MicroPython compatibility fallback for missing inspect
+    inspect = None  # type: ignore[assignment]
+
+try:
+    import warnings
+except ImportError:  # MicroPython compatibility fallback for missing warnings
+
+    class warnings:  # type: ignore[no-redef]
+        @staticmethod
+        def warn(*args: Any, **kwargs: Any) -> None:
+            pass
+
+
+try:
+    from collections import OrderedDict, defaultdict
+except ImportError:  # MicroPython compatibility fallback for missing collections
+
+    class OrderedDict(dict):  # type: ignore[no-redef]
+        pass
+
+    class defaultdict(dict):  # type: ignore[no-redef]
+        def __init__(self, default_factory: Any = None, *args: Any, **kwargs: Any):
+            super().__init__(*args, **kwargs)
+            self.default_factory = default_factory
+
+        def __missing__(self, key: Any) -> Any:
+            if self.default_factory is None:
+                raise KeyError(key)
+            ret = self[key] = self.default_factory()
+            return ret
+
+
+try:
+    from collections.abc import MutableMapping, MutableSequence, Sequence
+except ImportError:  # MicroPython compatibility fallback for missing collections.abc
+    MutableMapping = object  # type: ignore[assignment,misc]
+    MutableSequence = object  # type: ignore[assignment,misc]
+    Sequence = object  # type: ignore[assignment,misc]
+
+try:
+    _T = TypeVar("_T")
+except TypeError:
+    _T = object  # type: ignore[assignment,misc]
+
+try:
+    from copy import copy
+except ImportError:  # MicroPython compatibility fallback for missing copy
+
+    def copy(x: _T) -> _T:  # noqa: UP047  # type: ignore[misc,no-redef]
+        return x
+
+
+try:
+    import logging
+except ImportError:  # MicroPython compatibility fallback for missing logging
+
+    class logging:  # type: ignore[no-redef]
+        @staticmethod
+        def getLogger(name: str) -> Any:
+            class Logger:
+                def warning(self, msg: str, *args: Any) -> None:
+                    print(msg % args if args else msg)
+
+                def info(self, msg: str, *args: Any) -> None:
+                    print(msg % args if args else msg)
+
+                def debug(self, msg: str, *args: Any) -> None:
+                    pass
+
+                def error(self, msg: str, *args: Any) -> None:
+                    print(msg % args if args else msg)
+
+            return Logger()
+
+
+try:
+    from collections.abc import Hashable
+except ImportError:  # MicroPython compatibility fallback for missing collections.abc
+    Hashable = object  # type: ignore[assignment,misc]

--- a/src/closure_collector/core.py
+++ b/src/closure_collector/core.py
@@ -1,9 +1,17 @@
-import inspect
-from abc import ABCMeta, abstractmethod
-from collections.abc import Iterable, Mapping
-from pprint import pformat
-
-from closure_collector.util import ClosureCollectorException, is_rule, rebind
+from closure_collector.compat import (
+    ABCMeta,
+    Iterable,
+    Mapping,
+    abstractmethod,
+    pformat,
+)
+from closure_collector.util import (
+    ClosureCollectorException,
+    get_cell_contents,
+    is_rule,
+    is_zero_arg,
+    rebind,
+)
 
 CLOSURE_ATTRS = {"root", "cache", "peers", "promises"}
 
@@ -150,17 +158,18 @@ class ClosurePromiseCollector(DynamicClosureCollector):
         return bool(self.promises)
 
     def make_callable(self, value):
-        if callable(value) and len(inspect.signature(value).parameters) == 0:
+        if is_zero_arg(value):
             ret = value
             if isinstance(value, DynamicClosureCollector):
                 value.peers.add(self)
-                if value.root is None:
+                if getattr(value, "root", None) is None:
                     value.root = self
             # if it's a closure and there is something in there
             if hasattr(value, "__closure__") and value.__closure__:
                 for closure in value.__closure__:
-                    if isinstance(closure.cell_contents, DynamicClosureCollector):
-                        closure.cell_contents.peers.add(self)
+                    contents = get_cell_contents(closure)
+                    if isinstance(contents, DynamicClosureCollector):
+                        contents.peers.add(self)
         else:
             ret = lambda: value
         return ret

--- a/src/closure_collector/util.py
+++ b/src/closure_collector/util.py
@@ -1,5 +1,43 @@
-from numbers import Number
-from types import FunctionType
+from closure_collector.compat import Any, FunctionType, Number
+
+try:
+    from closure_collector.compat import inspect
+
+    if inspect is None:
+        raise ImportError
+
+    def is_zero_arg(value: Any) -> bool:
+        if not callable(value):
+            return False
+        return len(inspect.signature(value).parameters) == 0
+
+    def get_cell_contents(cell: Any) -> Any:
+        return cell.cell_contents
+
+    def set_cell_contents(cell: Any, value: Any) -> None:
+        cell.cell_contents = value
+
+except ImportError:  # MicroPython compatibility fallback for missing inspect
+
+    def is_zero_arg(value: Any) -> bool:
+        if not callable(value):
+            return False
+        try:
+            return value.__code__.co_argcount == 0
+        except AttributeError:
+            return True
+
+    def get_cell_contents(cell: Any) -> Any:
+        try:
+            return cell.cell_contents
+        except AttributeError:
+            return cell
+
+    def set_cell_contents(cell: Any, value: Any) -> None:
+        try:
+            cell.cell_contents = value
+        except AttributeError:
+            pass  # Read-only fallback in MicroPython
 
 
 class ClosureCollectorException(AttributeError):
@@ -9,8 +47,8 @@ class ClosureCollectorException(AttributeError):
 def rebind(callable, from_obj, to_obj):
     if getattr(callable, "__closure__", False):
         for cell in callable.__closure__:
-            if cell.cell_contents is from_obj:
-                cell.cell_contents = to_obj
+            if get_cell_contents(cell) is from_obj:
+                set_cell_contents(cell, to_obj)
 
 
 def is_rule(func):
@@ -19,7 +57,8 @@ def is_rule(func):
 
     if getattr(func, "__closure__", False):  ## TODO replace with inspect_getclosurevars, probably inspect only nonlocals
         for cell in func.__closure__:
-            if not isinstance(cell.cell_contents, str | Number | bytes | tuple | frozenset):
+            contents = get_cell_contents(cell)
+            if not isinstance(contents, (str, Number, bytes, tuple, frozenset)):
                 return True
     try:
         if set(func.__globals__).intersection(func.__code__.co_names):

--- a/src/flock/core.py
+++ b/src/flock/core.py
@@ -1,18 +1,18 @@
-import inspect
-import warnings
-from abc import ABCMeta, abstractmethod
-from collections import OrderedDict, defaultdict
-from collections.abc import (
+from closure_collector.compat import (
+    ABCMeta,
     Iterable,
     Mapping,
     MutableMapping,
     MutableSequence,
+    OrderedDict,
     Sequence,
+    abstractmethod,
+    copy,
+    defaultdict,
+    warnings,
 )
-from copy import copy
-
 from closure_collector.core import CCBase, DynamicClosureCollector
-from closure_collector.util import is_rule
+from closure_collector.util import get_cell_contents, is_rule, is_zero_arg
 from flock.util import FlockException
 
 __author__ = "Andy Fundinger"
@@ -98,14 +98,15 @@ class MutableFlock(FlockBase, DynamicClosureCollector):
         "Reminder to implement Mapping"
 
     def make_callable(self, value):
-        if callable(value) and len(inspect.signature(value).parameters) == 0:
+        if is_zero_arg(value):
             ret = value
             # if it's a closure and there is something in there
             if hasattr(value, "__closure__") and value.__closure__:
                 for closure in value.__closure__:
-                    if isinstance(closure.cell_contents, DynamicClosureCollector):
-                        closure.cell_contents.peers.add(self)
-        elif isinstance(value, Mapping):
+                    contents = get_cell_contents(closure)
+                    if isinstance(contents, DynamicClosureCollector):
+                        contents.peers.add(self)
+        elif isinstance(value, Mapping) and Mapping is not object:
             ret = FlockDict(value, root=self.root if self.root is not None else self)
         else:
             ret = lambda: value

--- a/src/flock/util.py
+++ b/src/flock/util.py
@@ -1,5 +1,4 @@
-import logging
-from collections.abc import Hashable, MutableMapping
+from closure_collector.compat import Hashable, MutableMapping, logging
 
 log = logging.getLogger(__name__)
 

--- a/test/test_micropython_core.py
+++ b/test/test_micropython_core.py
@@ -1,0 +1,61 @@
+from flock.core import FlockDict
+
+
+def test_flockdict_basic():
+    my_flock = FlockDict()
+    my_flock["a"] = 10
+    my_flock["b"] = 20
+    my_flock["c"] = lambda: my_flock["a"] + my_flock["b"]
+
+    assert my_flock["a"] == 10
+    assert my_flock["b"] == 20
+    assert my_flock["c"] == 30
+
+
+def test_flockdict_nested():
+    my_flock = FlockDict()
+    my_flock["nested"] = {"a": 1}
+    my_flock["derived"] = lambda: my_flock["nested"]["a"] + 1
+
+    assert my_flock["nested"]["a"] == 1
+    assert my_flock["derived"] == 2
+
+
+def test_flockdict_update():
+    my_flock = FlockDict()
+    my_flock["a"] = 1
+    my_flock["b"] = lambda: my_flock["a"] * 2
+
+    assert my_flock["b"] == 2
+    my_flock["a"] = 5
+    assert my_flock["b"] == 10
+
+
+def run_all_tests():
+    tests = [test_flockdict_basic, test_flockdict_nested, test_flockdict_update]
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+            print(f"PASS: {test.__name__}")
+        except Exception as e:
+            failed += 1
+            print(f"FAIL: {test.__name__}")
+            try:
+                import sys
+
+                sys.print_exception(e)
+            except Exception:
+                print(e)
+
+    print(f"\nResults: {passed} passed, {failed} failed")
+    if failed > 0:
+        import sys
+
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    run_all_tests()


### PR DESCRIPTION
Rebases features introduced in PRs #36, #39, and #44, originally PRs #17 and #21, onto master. Fixes tox configuration to correctly run the MicroPython tests using the `micropython` executable rather than CPython.

---
*PR created automatically by Jules for task [7803714368146164178](https://jules.google.com/task/7803714368146164178) started by @Ciemaar*